### PR TITLE
Add 3D chess board pieces

### DIFF
--- a/chess-app/src/lib/Board.svelte
+++ b/chess-app/src/lib/Board.svelte
@@ -2,9 +2,12 @@
   import { Canvas, T } from '@threlte/core';
   import { OrbitControls } from '@threlte/extras';
 
+  import PieceComponent, { type PieceType } from './Piece.svelte';
+
   type Color = 'white' | 'black';
   interface Piece {
     id: number;
+    type: PieceType;
     color: Color;
     x: number;
     y: number;
@@ -14,9 +17,38 @@
   const squareSize = 1;
 
   let pieces: Piece[] = [
-    // pawns
-    ...Array.from({ length: 8 }, (__, i) => ({ id: i + 1, color: 'white' as const, x: i, y: 1 })),
-    ...Array.from({ length: 8 }, (__, i) => ({ id: i + 9, color: 'black' as const, x: i, y: 6 }))
+    // white pieces
+    { id: 1, type: 'rook', color: 'white', x: 0, y: 0 },
+    { id: 2, type: 'knight', color: 'white', x: 1, y: 0 },
+    { id: 3, type: 'bishop', color: 'white', x: 2, y: 0 },
+    { id: 4, type: 'queen', color: 'white', x: 3, y: 0 },
+    { id: 5, type: 'king', color: 'white', x: 4, y: 0 },
+    { id: 6, type: 'bishop', color: 'white', x: 5, y: 0 },
+    { id: 7, type: 'knight', color: 'white', x: 6, y: 0 },
+    { id: 8, type: 'rook', color: 'white', x: 7, y: 0 },
+    ...Array.from({ length: 8 }, (_, i) => ({
+      id: 9 + i,
+      type: 'pawn' as const,
+      color: 'white' as const,
+      x: i,
+      y: 1
+    })),
+    // black pieces
+    { id: 17, type: 'rook', color: 'black', x: 0, y: 7 },
+    { id: 18, type: 'knight', color: 'black', x: 1, y: 7 },
+    { id: 19, type: 'bishop', color: 'black', x: 2, y: 7 },
+    { id: 20, type: 'queen', color: 'black', x: 3, y: 7 },
+    { id: 21, type: 'king', color: 'black', x: 4, y: 7 },
+    { id: 22, type: 'bishop', color: 'black', x: 5, y: 7 },
+    { id: 23, type: 'knight', color: 'black', x: 6, y: 7 },
+    { id: 24, type: 'rook', color: 'black', x: 7, y: 7 },
+    ...Array.from({ length: 8 }, (_, i) => ({
+      id: 25 + i,
+      type: 'pawn' as const,
+      color: 'black' as const,
+      x: i,
+      y: 6
+    }))
   ];
 
   let selected: Piece | null = null;
@@ -50,12 +82,11 @@
   {/each}
 
   {#each pieces as p (p.id)}
-    <T.Mesh
-      position={[p.x - boardSize / 2 + 0.5, 0.5, p.y - boardSize / 2 + 0.5]}
+    <T.Group
+      position={[p.x - boardSize / 2 + 0.5, 0, p.y - boardSize / 2 + 0.5]}
       on:click={() => handlePieceClick(p)}>
-      <T.CylinderGeometry args={[0.3, 0.3, 1, 32]} />
-      <T.MeshStandardMaterial color={p.color === 'white' ? '#ffffff' : '#000000'} />
-    </T.Mesh>
+      <PieceComponent type={p.type} color={p.color} />
+    </T.Group>
   {/each}
 
   <OrbitControls />

--- a/chess-app/src/lib/Piece.svelte
+++ b/chess-app/src/lib/Piece.svelte
@@ -1,0 +1,74 @@
+<script context="module" lang="ts">
+  export type PieceType = 'pawn' | 'rook' | 'knight' | 'bishop' | 'queen' | 'king';
+</script>
+
+<script lang="ts">
+  import { T } from '@threlte/core';
+
+  export let type: PieceType;
+  export let color: 'white' | 'black';
+
+  const materialColor = color === 'white' ? '#ffffff' : '#000000';
+</script>
+
+<T.Group>
+  {#if type === 'pawn'}
+    <T.Mesh>
+      <T.CylinderGeometry args={[0.35, 0.4, 0.4, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.4, 0]}>
+      <T.SphereGeometry args={[0.25, 32, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+  {:else if type === 'rook'}
+    <T.Mesh>
+      <T.CylinderGeometry args={[0.4, 0.45, 0.6, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.3, 0]}>
+      <T.BoxGeometry args={[0.5, 0.2, 0.5]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+  {:else if type === 'knight'}
+    <T.Mesh>
+      <T.CylinderGeometry args={[0.4, 0.45, 0.6, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.6, 0]} rotation={[Math.PI / 2, 0, 0]}>
+      <T.ConeGeometry args={[0.35, 0.6, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+  {:else if type === 'bishop'}
+    <T.Mesh>
+      <T.CylinderGeometry args={[0.35, 0.4, 0.6, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.6, 0]}>
+      <T.ConeGeometry args={[0.3, 0.5, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+  {:else if type === 'queen'}
+    <T.Mesh>
+      <T.CylinderGeometry args={[0.4, 0.45, 0.8, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.8, 0]}>
+      <T.SphereGeometry args={[0.25, 32, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+  {:else}
+    <T.Mesh>
+      <T.CylinderGeometry args={[0.4, 0.45, 0.8, 32]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.8, 0]} rotation={[0, 0, Math.PI / 4]}>
+      <T.BoxGeometry args={[0.05, 0.5, 0.05]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+    <T.Mesh position={[0, 0.8, 0]} rotation={[0, 0, 0]}>
+      <T.BoxGeometry args={[0.5, 0.05, 0.05]} />
+      <T.MeshStandardMaterial color={materialColor} />
+    </T.Mesh>
+  {/if}
+</T.Group>


### PR DESCRIPTION
## Summary
- create `Piece.svelte` describing simple models for each chess piece
- update `Board.svelte` to use `Piece` models and include full chess setup

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6849e07446088326a7cc0271a4414b63